### PR TITLE
Add Minecraft mod skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/build/
+/.gradle/
+/.idea/
+out/
+*.iml

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,40 @@
+plugins {
+    id 'java'
+    id 'net.minecraftforge.gradle' version '6.0.15'
+}
+
+group = 'com.example'
+version = '1.0.0'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+minecraft {
+    // Placeholder mappings and run configurations
+}
+
+repositories {
+    mavenCentral()
+    maven { url 'https://maven.minecraftforge.net' }
+}
+
+dependencies {
+    minecraft 'net.minecraftforge:forge:1.20.1-47.1.0'
+}
+
+jar {
+    manifest {
+        attributes(
+            'Specification-Title': 'mode',
+            'Specification-Vendor': 'example',
+            'Specification-Version': '1',
+            'Implementation-Title': project.name,
+            'Implementation-Version': project.version,
+            'Implementation-Vendor': 'example',
+            'Implementation-Timestamp': new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
+        )
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'mode'

--- a/src/main/java/com/example/mode/ExampleMod.java
+++ b/src/main/java/com/example/mode/ExampleMod.java
@@ -1,0 +1,12 @@
+package com.example.mode;
+
+import net.minecraftforge.fml.common.Mod;
+
+@Mod(ExampleMod.MODID)
+public class ExampleMod {
+    public static final String MODID = "mode";
+
+    public ExampleMod() {
+        // Register mod setup code here
+    }
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,0 +1,30 @@
+modLoader="javafml"
+loaderVersion="[47,)"
+license="All Rights Reserved"
+
+[[mods]]
+modId="mode"
+version="1.0.0"
+displayName="Mode Example Mod"
+updateJSONURL=""
+displayURL=""
+logoFile=""
+credits=""
+authors=""
+description='''
+An example mod skeleton.
+'''
+
+[[dependencies.mode]]
+modId="forge"
+mandatory=true
+versionRange="[47.1.0,)"
+ordering="NONE"
+side="BOTH"
+
+[[dependencies.mode]]
+modId="minecraft"
+mandatory=true
+versionRange="[1.20.1]"
+ordering="NONE"
+side="BOTH"

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 12,
+    "description": "Mode Example Mod Resources"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold a minimal Forge mod with ExampleMod class
- set up mods.toml and pack metadata
- configure Gradle build files

## Testing
- `gradle tasks --all` *(fails: plugin not found due to network restrictions)*
- `gradle test` *(fails: plugin not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68503ef9bf38832da462e2e998fcb8e3