### PR TITLE
Add fake player spawn command

### DIFF
--- a/src/main/java/com/example/mode/ExampleMod.java
+++ b/src/main/java/com/example/mode/ExampleMod.java
@@ -1,5 +1,9 @@
 package com.example.mode;
 
+import com.example.mode.command.SpawnPlayerCommand;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
 @Mod(ExampleMod.MODID)
@@ -7,6 +11,11 @@ public class ExampleMod {
     public static final String MODID = "mode";
 
     public ExampleMod() {
-        // Register mod setup code here
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void onRegisterCommands(RegisterCommandsEvent event) {
+        SpawnPlayerCommand.register(event.getDispatcher());
     }
 }

--- a/src/main/java/com/example/mode/command/SpawnPlayerCommand.java
+++ b/src/main/java/com/example/mode/command/SpawnPlayerCommand.java
@@ -1,0 +1,34 @@
+package com.example.mode.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraftforge.common.util.FakePlayer;
+import net.minecraftforge.common.util.FakePlayerFactory;
+import com.mojang.authlib.GameProfile;
+import java.util.UUID;
+
+public class SpawnPlayerCommand {
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(
+                Commands.literal("spawnplayer")
+                        .requires(source -> source.hasPermission(2))
+                        .then(Commands.argument("name", StringArgumentType.word())
+                                .executes(ctx -> spawn(ctx, StringArgumentType.getString(ctx, "name"))))
+        );
+    }
+
+    private static int spawn(CommandContext<CommandSourceStack> ctx, String name) {
+        CommandSourceStack source = ctx.getSource();
+        ServerLevel level = source.getLevel();
+        GameProfile profile = new GameProfile(UUID.randomUUID(), name);
+        FakePlayer fakePlayer = FakePlayerFactory.get(level, profile);
+        fakePlayer.moveTo(source.getPosition().x, source.getPosition().y, source.getPosition().z, source.getRotation().y, 0.0F);
+        level.addFreshEntity(fakePlayer);
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary
- register events in ExampleMod
- add `/spawnplayer` command to spawn a fake player

## Testing
- `gradle build` *(fails: Plugin [id: 'net.minecraftforge.gradle', version: '6.0.15'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850442593bc832db612ebfcc2145809