### PR TITLE
Add auto hunting command and screen

### DIFF
--- a/src/main/java/com/example/mode/client/AutoHuntClient.java
+++ b/src/main/java/com/example/mode/client/AutoHuntClient.java
@@ -1,0 +1,24 @@
+package com.example.mode.client;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.minecraft.client.MinecraftClient;
+
+public class AutoHuntClient implements ClientModInitializer {
+    @Override
+    public void onInitializeClient() {
+        // Register client command to open the AutoHunt UI
+        ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) -> {
+            dispatcher.register(ClientCommandManager.literal("autohuntui")
+                    .executes(context -> {
+                        MinecraftClient.getInstance().setScreen(new AutoHuntScreen());
+                        return 1;
+                    }));
+        });
+
+        // Register tick handler for automatic hunting logic
+        ClientTickEvents.END_CLIENT_TICK.register(client -> AutoHunter.onClientTick(client));
+    }
+}

--- a/src/main/java/com/example/mode/client/AutoHuntScreen.java
+++ b/src/main/java/com/example/mode/client/AutoHuntScreen.java
@@ -1,0 +1,33 @@
+package com.example.mode.client;
+
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.ButtonWidget.PressAction;
+import net.minecraft.text.Text;
+
+public class AutoHuntScreen extends Screen {
+    public AutoHuntScreen() {
+        super(Text.literal("Auto Hunt"));
+    }
+
+    @Override
+    protected void init() {
+        int centerX = this.width / 2;
+        int centerY = this.height / 2;
+        // Button to hunt hostile mobs only
+        this.addDrawableChild(ButtonWidget.builder(Text.literal("Hostile Only"), (PressAction) button -> {
+            AutoHunter.start(false);
+            this.close();
+        }).dimensions(centerX - 100, centerY - 10, 200, 20).build());
+
+        // Button to hunt all mobs
+        this.addDrawableChild(ButtonWidget.builder(Text.literal("All Mobs"), (PressAction) button -> {
+            AutoHunter.start(true);
+            this.close();
+        }).dimensions(centerX - 100, centerY + 15, 200, 20).build());
+    }
+
+    private void close() {
+        this.client.setScreen(null);
+    }
+}

--- a/src/main/java/com/example/mode/client/AutoHunter.java
+++ b/src/main/java/com/example/mode/client/AutoHunter.java
@@ -1,0 +1,50 @@
+package com.example.mode.client;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.mob.HostileEntity;
+import net.minecraft.util.math.Vec3d;
+
+import java.util.Comparator;
+
+public class AutoHunter {
+    private static boolean active = false;
+    private static boolean killAll = false;
+
+    public static void start(boolean huntAll) {
+        active = true;
+        killAll = huntAll;
+    }
+
+    public static void stop() {
+        active = false;
+    }
+
+    static void onClientTick(MinecraftClient client) {
+        if (!active || client.player == null || client.world == null) {
+            return;
+        }
+
+        // Find nearest target entity
+        Entity target = client.world.getEntities().stream()
+                .filter(e -> e instanceof LivingEntity)
+                .filter(e -> killAll || e instanceof HostileEntity)
+                .filter(e -> e != client.player)
+                .min(Comparator.comparingDouble(e -> e.squaredDistanceTo(client.player)))
+                .orElse(null);
+
+        if (target == null) return;
+
+        // Simple movement toward target (ignores obstacles)
+        Vec3d direction = target.getPos().subtract(client.player.getPos());
+        Vec3d velocity = direction.normalize().multiply(0.5);
+        client.player.addVelocity(velocity.x, velocity.y, velocity.z);
+
+        // If close enough, attack
+        if (client.player.squaredDistanceTo(target) < 4.0) {
+            client.interactionManager.attackEntity(client.player, target);
+            client.player.swingHand(client.player.getActiveHand());
+        }
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -9,7 +9,8 @@
   "license": "All Rights Reserved",
   "environment": "*",
   "entrypoints": {
-    "main": ["com.example.mode.ExampleMod"]
+    "main": ["com.example.mode.ExampleMod"],
+    "client": ["com.example.mode.client.AutoHuntClient"]
   },
   "depends": {
     "fabricloader": ">=0.14.22",


### PR DESCRIPTION
## Summary
- add a `client` entry point for a new auto hunter feature
- create a simple AutoHunt UI with buttons for hostile-only vs all mobs
- implement basic logic that moves toward nearby mobs and attacks
- register a client command `/autohuntui` to open the UI

## Testing
- `gradle build` *(fails: Plugin [id: 'fabric-loom', version: '1.5-SNAPSHOT'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504c92ca44832d86ddf41c6908f196